### PR TITLE
Add single validateURL helper

### DIFF
--- a/src/components/URLInput.tsx
+++ b/src/components/URLInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { Upload, Plus, FileText, X } from 'lucide-react';
-import { parseCSV, validateURL } from '../utils/export';
+import { parseCSV } from '../utils/export';
+import { validateURL } from '../utils/validators';
 
 interface URLInputProps {
   onAddURLs: (urls: string[]) => void;

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,14 +1,5 @@
 import { URLItem } from '../types';
 
-export const validateURL = (url: string): boolean => {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 export const exportToCSV = (data: URLItem[]): string => {
   const headers = [
     'URL',

--- a/src/utils/scraper.ts
+++ b/src/utils/scraper.ts
@@ -27,11 +27,4 @@ export const extractMainContent = (html: string): string => {
   return html;
 };
 
-export const validateURL = (url: string): boolean => {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
-};
+export { validateURL } from './validators';

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,0 +1,8 @@
+export const validateURL = (url: string): boolean => {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- centralize `validateURL` helper in `src/utils/validators.ts`
- remove duplicated implementations
- update imports across the project

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844a08e63d08329869f52f30335921f