### PR TITLE
Add Vitest setup and initial tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -28,6 +29,10 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.5.1",
+    "@testing-library/react": "^15.1.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Header from '../Header';
+
+describe('Header', () => {
+  it('renders the app title', () => {
+    render(<Header darkMode={false} onToggleDarkMode={() => {}} />);
+    expect(screen.getByText('CCMeta.ai')).toBeInTheDocument();
+  });
+});

--- a/src/utils/__tests__/export.test.ts
+++ b/src/utils/__tests__/export.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { exportToCSV } from '../export';
+import type { URLItem } from '../../types';
+
+describe('exportToCSV', () => {
+  it('creates CSV string with headers and data', () => {
+    const items: URLItem[] = [
+      {
+        id: '1',
+        url: 'https://example.com',
+        status: 'completed',
+        framework: { name: 'AIDA', code: 'AIDA', description: '', color: '', justification: 'just' },
+        titles: ['Title1', 'Title2', 'Title3'],
+        metaDescriptions: ['Desc1', 'Desc2', 'Desc3'],
+        createdAt: new Date(),
+      },
+    ];
+
+    const csv = exportToCSV(items);
+    expect(csv.startsWith('"URL","Status","Framework"')).toBe(true);
+    expect(csv).toContain('"https://example.com"');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,9 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts',
+  },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add basic testing dependencies
- configure Vitest in `vite.config.ts`
- add setup file for React Testing Library
- create tests for `exportToCSV` utility and `Header` component
- add `.gitignore`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a09ae2e483299c02c69ac2e7334e