### PR TITLE
Add per-URL text export and multi-entry support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import ResultsModal from './components/ResultsModal';
 import { scrapeURL, extractMainContent } from './utils/scraper';
 import { detectFramework } from './utils/frameworks';
 import { generateSEOContent } from './utils/seoGenerator';
-import { exportToCSV, downloadFile } from './utils/export';
+import { exportToCSV, downloadFile, saveContentAsTxt } from './utils/export';
 
 function App() {
   const [urls, setUrls] = useState<URLItem[]>(() => {
@@ -88,6 +88,8 @@ function App() {
       // Scrape content
       const htmlContent = await scrapeURL(urlItem.url);
       const textContent = extractMainContent(htmlContent);
+
+      saveContentAsTxt(urlItem.url, textContent);
       
       // Detect framework
       const framework = detectFramework(textContent);

--- a/src/components/URLInput.tsx
+++ b/src/components/URLInput.tsx
@@ -9,21 +9,27 @@ interface URLInputProps {
 }
 
 const URLInput: React.FC<URLInputProps> = ({ onAddURLs, isProcessing }) => {
-  const [manualUrl, setManualUrl] = useState('');
+  const [manualUrls, setManualUrls] = useState('');
   const [dragOver, setDragOver] = useState(false);
   const [error, setError] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleManualAdd = () => {
-    if (!manualUrl.trim()) return;
-    
-    if (!validateURL(manualUrl)) {
-      setError('URL invalide. Veuillez entrer une URL complète (ex: https://example.com)');
+    const rawUrls = manualUrls
+      .split(/[,\n\s]+/)
+      .map(u => u.trim())
+      .filter(Boolean);
+
+    if (rawUrls.length === 0) return;
+
+    const invalid = rawUrls.filter(url => !validateURL(url));
+    if (invalid.length > 0) {
+      setError('Une ou plusieurs URLs sont invalides');
       return;
     }
-    
-    onAddURLs([manualUrl]);
-    setManualUrl('');
+
+    onAddURLs(rawUrls);
+    setManualUrls('');
     setError('');
   };
 
@@ -91,21 +97,19 @@ const URLInput: React.FC<URLInputProps> = ({ onAddURLs, isProcessing }) => {
       {/* Manual URL Input */}
       <div className="mb-6">
         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-          Ajouter une URL manuellement
+          Ajouter des URLs manuellement
         </label>
         <div className="flex space-x-2">
-          <input
-            type="url"
-            value={manualUrl}
-            onChange={(e) => setManualUrl(e.target.value)}
-            placeholder="https://example.com"
-            className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-800 dark:text-white"
+          <textarea
+            value={manualUrls}
+            onChange={(e) => setManualUrls(e.target.value)}
+            placeholder="https://example.com\nhttps://exemple.org"
+            className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-800 dark:text-white h-24 resize-none"
             disabled={isProcessing}
-            onKeyPress={(e) => e.key === 'Enter' && handleManualAdd()}
           />
           <button
             onClick={handleManualAdd}
-            disabled={isProcessing || !manualUrl.trim()}
+            disabled={isProcessing || !manualUrls.trim()}
             className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center space-x-2 transition-colors"
           >
             <Plus className="w-4 h-4" />

--- a/src/utils/__tests__/export.test.ts
+++ b/src/utils/__tests__/export.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { exportToCSV } from '../export';
+import { describe, it, expect, vi } from 'vitest';
+import * as exportUtils from '../export';
+const { exportToCSV, saveContentAsTxt } = exportUtils;
 import type { URLItem } from '../../types';
 
 describe('exportToCSV', () => {
@@ -19,5 +20,14 @@ describe('exportToCSV', () => {
     const csv = exportToCSV(items);
     expect(csv.startsWith('"URL","Status","Framework"')).toBe(true);
     expect(csv).toContain('"https://example.com"');
+  });
+
+  it('saves content with sanitized filename', () => {
+    const spy = vi.spyOn(exportUtils, 'downloadFile');
+    saveContentAsTxt('https://Example.com/some/path', 'hello');
+    expect(spy).toHaveBeenCalled();
+    const args = (spy as any).mock.calls[0];
+    expect(args[1]).toMatch(/example_com_some_path\.txt$/);
+    spy.mockRestore();
   });
 });

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -64,3 +64,11 @@ export const parseCSV = (csvText: string): string[] => {
   
   return [...new Set(urls)]; // Remove duplicates
 };
+
+export const saveContentAsTxt = (url: string, content: string) => {
+  const sanitized = url
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  downloadFile(content, `${sanitized || 'page'}.txt`, 'text/plain');
+};


### PR DESCRIPTION
## Summary
- allow entering several URLs at once via textarea
- provide `saveContentAsTxt` helper to store scraped text
- export content to a `.txt` file when scraping each URL
- test the helper function

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a9b558748329a57f5321fd335349