### PR TITLE
Add Node version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CCMeta.ai is a React and TypeScript application for generating SEO metadata. You
 
 ## Installation
 
-1. Ensure you have **Node.js 18** or later installed.
+1. Ensure you have **Node.js 18** or later installed. The `package.json` file specifies this requirement using an `engines` field.
 2. Install dependencies:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- enforce Node 18 or later via `engines` field in `package.json`
- note the Node version requirement in the README

## Testing
- `npm test` *(fails: vitest not installed)*
- `npm run lint` *(fails: cannot find eslint packages)*

------
https://chatgpt.com/codex/tasks/task_e_6845b59e707883299baf1f4d78a8502d